### PR TITLE
Add how to install jekyll

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,20 @@ The content pages can be found [in `/docs/`](/docs/)
 ## Installation
 If you are on debian derivates go install build-essentials:
 ```
- apt install build-essential
+apt install build-essential
 ```
 Then you can use the Ruby Dependency Management to build all you need:
 ```
- bundle install jekyll
- bundle install
+bundle install
 ```
 Start jekyll like this:
 ```
- bundle exec jekyll serve
+bundle exec jekyll serve
+```
+If you experience troubles, make sure to not have jekyll installed via you
+package manager. On debian derivates do:
+```
+apt purge jekyll
 ```
 
 ## Note

--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@ For the documentation see: http://metafacture.github.io/metafacture-documentatio
 
 This repo is the central place for the documentation about Metafacture that we render using the jekyll template [Just the docs](https://github.com/just-the-docs/just-the-docs).
 
-The content pages can be found [here in `/docs/`](/docs/)
+The content pages can be found [in `/docs/`](/docs/)
 
+## Installation
+If you are on debian derivates go install build-essentials:
+```
+ apt install build-essential
+```
+Then you can use the Ruby Dependency Management to build all you need:
+```
+ bundle install jekyll
+ bundle install
+```
+Start jekyll like this:
+```
+ bundle exec jekyll serve
+```
+
+## Note
 > [!NOTE]
-> With regard to the Transformation-Modules this documentation focusses on Fix instead of MORPH. If you want to find out more about MORPH. Have a look at [the old documentation](https://github.com/metafacture/metafacture-core/wiki/Metamorph-User-Guide) and the german cookbook by [Swissbib](https://swissbib.gitlab.io/metamorph-doku/).
-
+> With regard to the Transformation-Modules this documentation focusses on Fix instead of Morph. If you want to find out more about Morph have a look at [the old documentation](https://github.com/metafacture/metafacture-core/wiki/Metamorph-User-Guide) and the german cookbook by [Swissbib](https://swissbib.gitlab.io/metamorph-doku/).
 
 Our goal with this repo is to collaboratively create comprehensive documentation on Metafacture in the [issue tracker](https://github.com/metafacture/metafacture-documentation/issues?q=). Feel free to open issues not only for bugs or enhancements, but also questions about Metafacture usage, or to share your experiences. We hope that over time, in that way we can create useful tutorials, how-tos, and collect good practices for using Metafacture.
 


### PR DESCRIPTION
I had many issues by using `jekyll` from the official repositories, as well as on Debian Testing as on Debian Bookworm.
The solution here worked for me (well I hope I have written down everything correctly).